### PR TITLE
Move chat widget from index to footer

### DIFF
--- a/components/layouts/footers/DefaultFooter.tsx
+++ b/components/layouts/footers/DefaultFooter.tsx
@@ -196,6 +196,7 @@ export default function DefaultFooter() {
                     </p>
                 </div>
             </div>
+            <script src="//code.tidio.co/bga3j5sbenpxlnttpeyg1zk2yew5k0ep.js" async></script>
         </footer>
     );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -107,7 +107,6 @@ export default function HomePage() {
                                 features that will be added to the platform in
                                 the coming months.
                             </p>
-                            <script src="//code.tidio.co/bga3j5sbenpxlnttpeyg1zk2yew5k0ep.js" async></script>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
We can place the chat widget on the footer component to show it on all pages.